### PR TITLE
Better handling of GIL etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,5 @@ script:
   - ghc -dynamic-too -shared -fPIC Test.hs -no-link
   - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE
   - python${PY_VER} hyphen_examples_full.py -v
+  - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE --not-threaded
+  - python${PY_VER} hyphen_examples_full.py -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,5 +88,7 @@ test_script:
 - stack %STACK_FLAGS% build
 - stack %STACK_FLAGS% exec -- ghc --version
 - stack %STACK_FLAGS% exec -- python --version
+- stack %STACK_FLAGS% exec -- python hyphen\build-extn.py
+- stack %STACK_FLAGS% exec -- python hyphen_examples_full.py -v
 - stack %STACK_FLAGS% exec -- python hyphen\build-extn.py --not-threaded
 - stack %STACK_FLAGS% exec -- python hyphen_examples_full.py -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,5 +88,5 @@ test_script:
 - stack %STACK_FLAGS% build
 - stack %STACK_FLAGS% exec -- ghc --version
 - stack %STACK_FLAGS% exec -- python --version
-- stack %STACK_FLAGS% exec -- python hyphen\build-extn.py
+- stack %STACK_FLAGS% exec -- python hyphen\build-extn.py --not-threaded
 - stack %STACK_FLAGS% exec -- python hyphen_examples_full.py -v

--- a/hyphen/build-extn.py
+++ b/hyphen/build-extn.py
@@ -13,8 +13,14 @@ def flatten(args):
 
 def getopts():
     parser = optparse.OptionParser()
-    parser.add_option("-d", "--dynamic", action="store_const", const="dynamic", dest="dyn_or_static")
-    parser.add_option("-s", "--static",  action="store_const", const="static",  dest="dyn_or_static")
+    parser.add_option("-d", "--dynamic",      action="store_const",
+                      const="dynamic",        dest="dyn_or_static")
+    parser.add_option("-s", "--static",       action="store_const",
+                      const="static",         dest="dyn_or_static")
+    parser.add_option("-t", "--threaded",     action="store_const",
+                      const="threaded",     dest="threaded_or_not")
+    parser.add_option("-n", "--not-threaded", action="store_const",
+                      const="not-threaded", dest="threaded_or_not")
 
     opts, args = parser.parse_args()
     assert not args
@@ -24,6 +30,8 @@ def getopts():
             opts.dyn_or_static = 'static'
         else:
             opts.dyn_or_static = 'dynamic'
+    if opts.threaded_or_not is None:
+        opts.threaded_or_not = 'threaded'
 
     return opts
 
@@ -69,8 +77,11 @@ def cygpreppath(path):
 opts       = getopts()
 work_dir   = sys.path[0]
 ghc_ver    = subprocess.check_output(['ghc', '--numeric-version']).decode('ascii')
-HSrts_lib  = {'dynamic' : 'HSrts-ghc' + ghc_ver,
-              'static'  : 'HSrts'              }[opts.dyn_or_static]
+thrd_part  = {'threaded'    : '_thr',
+              'not-threaded' : ''   }[opts.threaded_or_not]
+final_part = {'dynamic' : '-ghc' + ghc_ver,
+              'static'  : ''              }[opts.dyn_or_static]
+HSrts_lib  = 'HSrts' + thrd_part + final_part
 py_include = distutils.sysconfig.get_python_inc()
 py_libdir  = distutils.sysconfig.get_config_var('LIBDIR')
 suffix     = distutils.sysconfig.get_config_var('EXT_SUFFIX')

--- a/hyphen/lowlevel_src/PythonBase.hs
+++ b/hyphen/lowlevel_src/PythonBase.hs
@@ -65,7 +65,7 @@ foreign import ccall pyObject_Call        :: PyObj -> PyObj -> PyObj -> IO PyObj
 foreign import ccall pyDict_New           :: IO PyObj
 foreign import ccall pyDict_Next  :: PyObj -> Ptr Int -> Ptr PyObj -> Ptr PyObj -> IO Int
 foreign import ccall pyDict_SetItem       :: PyObj -> PyObj -> PyObj -> IO Int
-foreign import ccall "&py_DECREF" addr_py_DECREF :: FunPtr (PyObj -> IO ())
+foreign import ccall "&py_DECREF_with_GIL_acq" addr_py_DECREF :: FunPtr (PyObj -> IO ())
 foreign import ccall py_DECREF            :: PyObj -> IO ()
 foreign import ccall py_INCREF            :: PyObj -> IO ()
 foreign import ccall pyModule_AddObject   :: PyObj -> CString -> PyObj -> IO Int

--- a/hyphen/lowlevel_src/PythonBase.hs
+++ b/hyphen/lowlevel_src/PythonBase.hs
@@ -44,6 +44,8 @@ foreign import ccall c_pyValueErr         :: CString -> IO PyObj
 foreign import ccall c_getHsExceptionAttr :: PyObj -> IO PyObj
 foreign import ccall c_installHaskellCtrlCHandler  :: IO Int
 foreign import ccall c_reinstallPythonCtrlCHandler :: IO Int
+foreign import ccall c_makeHaskellText    :: PyObj -> IO PyObj
+foreign import ccall unsafe c_isThisTheMainPythonThread :: IO Bool
 foreign import ccall pyErr_NoMemory       :: IO PyObj
 foreign import ccall pyErr_Fetch          :: Ptr PyObj -> Ptr PyObj -> Ptr PyObj -> IO ()
 foreign import ccall pyErr_NormalizeException

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -151,6 +151,17 @@ py_DECREF(HsPtr obj)
 }
 
 void
+py_DECREF_with_GIL_acq(HsPtr obj)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  Py_DECREF(obj);
+
+  PyGILState_Release(gstate);
+}
+
+void
 py_INCREF(HsPtr obj)
 {
   Py_INCREF(obj);

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -153,12 +153,15 @@ py_DECREF(HsPtr obj)
 void
 py_DECREF_with_GIL_acq(HsPtr obj)
 {
-  PyGILState_STATE gstate;
-  gstate = PyGILState_Ensure();
+  if (ghc_interpreter_state)
+    {
+      PyGILState_STATE gstate;
+      gstate = PyGILState_Ensure();
 
-  Py_DECREF(obj);
+      Py_DECREF(obj);
 
-  PyGILState_Release(gstate);
+      PyGILState_Release(gstate);
+    }
 }
 
 void

--- a/hyphen_examples.py
+++ b/hyphen_examples.py
@@ -97,11 +97,15 @@ to type
 >>> hs.Prelude.foldr((lambda x, y: x + y), 0, range(60))
 1770
 
+>>> import sys
+>>> old_recursion_limit = sys.getrecursionlimit()
+>>> sys.setrecursionlimit(300)
 >>> try:
 ...     hs.Prelude.foldr((lambda x, y: x + y), 0, range(10000))
 ... except RuntimeError as e:
 ...     print('maximum recursion depth exceeded' in str(e))
 True
+>>> sys.setrecursionlimit(old_recursion_limit)
 
 >>> hs.Prelude.replicate
 <hyphen.HsFunObj object of Haskell type GHC.Types.Int -> a -> [a]>

--- a/hyphen_examples.py
+++ b/hyphen_examples.py
@@ -94,9 +94,14 @@ to type
 >>> hs.Prelude.foldr((lambda x, y: x + y), 0, [1, 2, 3])
 6
 
->> hs.Prelude.foldr((lambda x, y: x + y), 0, range(10000))
-..
-RuntimeError: maximum recursion depth exceeded while calling a Python object
+>>> hs.Prelude.foldr((lambda x, y: x + y), 0, range(60))
+1770
+
+>>> try:
+...     hs.Prelude.foldr((lambda x, y: x + y), 0, range(10000))
+... except RuntimeError as e:
+...     print('maximum recursion depth exceeded' in str(e))
+True
 
 >>> hs.Prelude.replicate
 <hyphen.HsFunObj object of Haskell type GHC.Types.Int -> a -> [a]>

--- a/hyphen_examples_full.py
+++ b/hyphen_examples_full.py
@@ -102,7 +102,9 @@ False
 ...     assert hs.Test.foo(3) == 4
 """
 
-if __name__ == "__main__":
+import sys
+
+def runtest():
     import doctest, sys
     (fails1, _) = doctest.testmod()
     import hyphen.utils, hyphen.marshall_obj_to_hs, hyphen_examples
@@ -113,3 +115,14 @@ if __name__ == "__main__":
     if fails1 + fails2 + fails3 + fails4 > 0:
         print("Some failures")
         sys.exit(1)
+
+if __name__ == "__main__":
+    import hyphen
+    for GIL in 'GIL_mode_lazy', 'GIL_mode_fancy':
+        for sig in 'signal_mode_lazy', 'signal_mode_haskell', 'signal_mode_python':
+            print("**********************************************")
+            print("* TEST BATCH : " + GIL + " " + sig )
+            print("**********************************************")
+            getattr(hyphen.hslowlevel, 'set_' + GIL)()
+            getattr(hyphen.hslowlevel, 'set_' + sig)()
+            runtest()

--- a/hyphen_examples_full.py
+++ b/hyphen_examples_full.py
@@ -111,4 +111,5 @@ if __name__ == "__main__":
     (fails3, _) = doctest.testmod(hyphen.marshall_obj_to_hs)
     (fails4, _) = doctest.testmod(hyphen_examples)
     if fails1 + fails2 + fails3 + fails4 > 0:
+        print("Some failures")
         sys.exit(1)


### PR DESCRIPTION
Fix sundry problems with the GIL (and signals) handling:

- We used to release the GIL even if the Haskell RTS was not built to support multiple threads. We should only release the Python GIL if Haskell code can be called from multiple threads safely.
- Relatedly: we should build, by default, with the threaded RTS.
- We used to apply our various signal management schemes whenever we cross into Haskell. We should only do it when the *main thread* crosses into Haskell.
- We did not remove our signal management schemes when we cross back into Python. We do now.
- When we reacquire the GIL, we should make sure that all code between reacquisition and re-release takes place in an OS-bound thread.
