### PR TITLE
Add tests for GIL and signal fancy behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,19 @@ script:
   - ghc --version
   - ghc -dynamic-too -shared -fPIC Test.hs -no-link
   - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE
-  - python${PY_VER} hyphen_examples_full.py -v
+  - python${PY_VER} hyphen_examples_full.py
+  - # Test that the signal mode fancy stuff works (and that we get the expected behaviour with it disabled)
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 30 0 32
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 30 0 32
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 20 11 100
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_ei_with_nuisance_threads.py python 5 20 0 32
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_ei_with_nuisance_threads.py haskell 5 20 0 32
+  - # Test that releasing the GIL works (and that we get the expected behavior with it disabled)
+  - python${PY_VER} test_tools/test_GIL_release.py fancy 5 5 5 12
+  - python${PY_VER} test_tools/test_GIL_release.py lazy 5 5 24 100
+  - # Now test everything that still makes sense without the threaded Haskell rts
   - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE --not-threaded
-  - python${PY_VER} hyphen_examples_full.py -v
+  - python${PY_VER} hyphen_examples_full.py
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 30 0 32
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 30 0 32
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 20 11 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,17 +41,17 @@ script:
   - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE
   - python${PY_VER} hyphen_examples_full.py
   - # Test that the signal mode fancy stuff works (and that we get the expected behaviour with it disabled)
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 30 0 32
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 30 0 32
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 20 11 100
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_ei_with_nuisance_threads.py python 5 20 0 32
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_ei_with_nuisance_threads.py haskell 5 20 0 32
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 40 0 33
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 40 0 33
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 40 31 100
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_ei_with_nuisance_threads.py python 5 40 0 33
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_ei_with_nuisance_threads.py haskell 5 40 0 33
   - # Test that releasing the GIL works (and that we get the expected behavior with it disabled)
   - python${PY_VER} test_tools/test_GIL_release.py fancy 5 5 5 12
   - python${PY_VER} test_tools/test_GIL_release.py lazy 5 5 24 100
   - # Now test everything that still makes sense without the threaded Haskell rts
   - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE --not-threaded
   - python${PY_VER} hyphen_examples_full.py
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 30 0 32
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 30 0 32
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 20 11 100
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 40 0 33
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 40 0 33
+  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 40 31 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,3 @@ script:
   - # Now test everything that still makes sense without the threaded Haskell rts
   - python${PY_VER} hyphen/build-extn.py --$BUILD_TYPE --not-threaded
   - python${PY_VER} hyphen_examples_full.py
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py python 40 0 33
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py haskell 40 0 33
-  - python${PY_VER} test_tools/interrupting_after.py 30 python${PY_VER} test_tools/test_expecting_interruption.py lazy 40 31 100

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,6 +89,8 @@ test_script:
 - stack %STACK_FLAGS% exec -- ghc --version
 - stack %STACK_FLAGS% exec -- python --version
 - stack %STACK_FLAGS% exec -- python hyphen\build-extn.py
-- stack %STACK_FLAGS% exec -- python hyphen_examples_full.py -v
+- stack %STACK_FLAGS% exec -- python hyphen_examples_full.py
+- stack %STACK_FLAGS% exec -- python test_tools/test_GIL_release.py fancy 5 5 5 12
+- stack %STACK_FLAGS% exec -- python test_tools/test_GIL_release.py lazy 5 5 24 100
 - stack %STACK_FLAGS% exec -- python hyphen\build-extn.py --not-threaded
-- stack %STACK_FLAGS% exec -- python hyphen_examples_full.py -v
+- stack %STACK_FLAGS% exec -- python hyphen_examples_full.py

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -422,7 +422,7 @@ static void
 compound_sigint_handler(int signum)
 { /* Our private version of the Haskell signal handler */
   ++signal_count;
-  if (haskell_siginthandler)
+  if (haskell_siginthandler && ghc_interpreter_state)
     {
       (*haskell_siginthandler)(signum);
     }

--- a/test_tools/interrupting_after.py
+++ b/test_tools/interrupting_after.py
@@ -1,0 +1,16 @@
+
+"""Simple wrapper to run another process and send it a keyboard
+interrupt after a user-configurable delay; return+display the return
+code of the subprocess. POSIX only.
+
+"""
+
+import subprocess, sys, time, signal
+
+delay_before_interrupt_secs = int(sys.argv[1])
+ps = subprocess.Popen(sys.argv[2:])
+time.sleep(delay_before_interrupt_secs)
+ps.send_signal(signal.SIGINT)
+ps.wait()
+print("Subprocess exited with code: {}".format(ps.returncode))
+sys.exit(ps.returncode)

--- a/test_tools/test_GIL_release.py
+++ b/test_tools/test_GIL_release.py
@@ -1,0 +1,45 @@
+"""Simple code to test GIL release during Haskell code. Spawn n
+threads, each of which executes a threadDelay from Haskell of m
+seconds, then join all the threads. If we are releasing the GIL, this
+should only take m seconds, because the threadDelays all go in
+parallel, but if we are holding the GIL, then the threadDelays are
+sequenced and it will take nm seconds.
+
+"""
+import time, sys, threading
+
+sys.path[0] = sys.path[0] + '/..'
+
+import hyphen
+import hs.Control.Concurrent
+
+GIL_mode, num_threads = sys.argv[1], int (sys.argv[2])
+per_thread_wait, min_time_allowed, max_time_allowed = map(float, sys.argv[3:])
+
+def thread_worker():
+    hs.Control.Concurrent.threadDelay(int(per_thread_wait * 1e6)).act()
+
+
+assert GIL_mode in ["lazy", "fancy"]
+getattr(hyphen.hslowlevel, 'set_GIL_mode_' + GIL_mode)()
+
+threads = [threading.Thread(target=thread_worker)
+           for i in range(num_threads)]
+
+start_time = time.time()
+
+for t in threads:
+    t.start()
+
+for t in threads:
+    t.join()
+
+time_taken = time.time() - start_time
+print("All threads done after running for {:.2f}s".format(time_taken))
+
+if min_time_allowed < time_taken  < max_time_allowed:
+    print("OK")
+    sys.exit(0)
+else:
+    print("Not OK.")
+    sys.exit(1)

--- a/test_tools/test_ei_with_nuisance_threads.py
+++ b/test_tools/test_ei_with_nuisance_threads.py
@@ -1,0 +1,46 @@
+import time, sys, threading
+
+sys.path[0] = sys.path[0] + '/..'
+start_time = time.time()
+
+import hyphen
+import hs.Control.Concurrent
+
+load_time_taken = time.time() - start_time
+print("Hyphen loaded after running for {:.2f}s".format(load_time_taken))
+
+signal_mode, num_nuisance_threads = sys.argv[1], int(sys.argv[2])
+assert signal_mode in ["lazy", "haskell", "python"]
+getattr(hyphen.hslowlevel, 'set_signal_mode_' + signal_mode)()
+wait_seconds, min_total_time_allowed_postload, max_total_time_allowed = map(float, sys.argv[3:])
+
+thread_was_interrupted = [False]
+
+def nuisance_thread_worker():
+    try:
+        hs.Control.Concurrent.threadDelay(int(wait_seconds * 1e6)).act()
+    except KeyboardInterrupt:
+        thread_was_interrupted[0] = True
+
+threads = [threading.Thread(target=nuisance_thread_worker)
+           for i in range(num_nuisance_threads)]
+
+for t in threads:
+    t.start()
+
+try:
+    hs.Control.Concurrent.threadDelay(int(wait_seconds * 1e6)).act()
+except KeyboardInterrupt:
+    pass
+
+time_taken = time.time() - start_time
+print("Interrupted after running for {:.2f}s".format(time_taken))
+
+for t in threads:
+    t.join()
+
+if not thread_was_interrupted[0] and (
+        min_total_time_allowed_postload + load_time_taken < time_taken  < max_total_time_allowed):
+    sys.exit(0)
+else:
+    sys.exit(1)

--- a/test_tools/test_expecting_interruption.py
+++ b/test_tools/test_expecting_interruption.py
@@ -1,0 +1,28 @@
+import time, sys
+
+sys.path[0] = sys.path[0] + '/..'
+start_time = time.time()
+
+import hyphen
+import hs.Control.Concurrent
+
+load_time_taken = time.time() - start_time
+print("Hyphen loaded after running for {:.2f}s".format(load_time_taken))
+
+signal_mode = sys.argv[1]
+assert signal_mode in ["lazy", "haskell", "python"]
+getattr(hyphen.hslowlevel, 'set_signal_mode_' + signal_mode)()
+wait_seconds, min_total_time_allowed_postload, max_total_time_allowed = map(float, sys.argv[2:])
+
+try:
+    hs.Control.Concurrent.threadDelay(int(wait_seconds * 1e6)).act()
+except KeyboardInterrupt:
+    pass
+
+time_taken = time.time() - start_time
+print("Interrupted after running for {:.2f}s".format(time_taken))
+
+if min_total_time_allowed_postload + load_time_taken < time_taken  < max_total_time_allowed:
+    sys.exit(0)
+else:
+    sys.exit(1)


### PR DESCRIPTION
There were previously no tests for the fancy behaviors where we (optionally) release the GIL while running Haskell code, and where we arrange that signals can interrupt the python program even when it is in Haskell code. Add tests for these things (the signal code is only tested on POSIX, because it seems to be very hard on windows to simulate sending control-C to a process).