### PR TITLE
Use foreign import "unsafe" where appropriate

### DIFF
--- a/hyphen/lowlevel_src/HyphenWrapping.hs
+++ b/hyphen/lowlevel_src/HyphenWrapping.hs
@@ -41,35 +41,36 @@ import HsObjRaw
 -- and its only element is a HsObjRaw (say), then pulling out the
 -- HsObjRaw (this is useful for parsing argument tuples...)
 
-foreign import ccall pyHsObjRaw_Check           :: PyObj -> IO Bool
-foreign import ccall pyHsType_Check             :: PyObj -> IO Bool
-foreign import ccall pyTyCon_Check              :: PyObj -> IO Bool
-foreign import ccall parseTupleToPythonHsObjRaw :: PyObj -> IO PyObj
-foreign import ccall parseTupleToPythonHsType   :: PyObj -> IO PyObj
+foreign import ccall unsafe pyHsObjRaw_Check           :: PyObj -> IO Bool
+foreign import ccall unsafe pyHsType_Check             :: PyObj -> IO Bool
+foreign import ccall unsafe pyTyCon_Check              :: PyObj -> IO Bool
+foreign import ccall unsafe parseTupleToPythonHsObjRaw :: PyObj -> IO PyObj
+foreign import ccall unsafe parseTupleToPythonHsType   :: PyObj -> IO PyObj
 
 formSimpleHsObjRaw :: (Typeable a) => a -> IO PyObj
 formSimpleHsObjRaw = wrapPythonHsObjRaw <=< formObjSimple
 
-foreign import ccall c_unwrapPythonTyCon  :: PyObj -> WStPtr
+foreign import ccall unsafe c_unwrapPythonTyCon  :: PyObj -> WStPtr
 unwrapPythonTyCon  :: PyObj -> IO TyCon
 unwrapPythonTyCon  = deRefStablePtr . castPtrToStablePtr . c_unwrapPythonTyCon
 
-foreign import ccall c_wrapPythonTyCon  :: WStPtr -> IO PyObj
+foreign import ccall unsafe c_wrapPythonTyCon  :: WStPtr -> IO PyObj
 wrapPythonTyCon    :: TyCon  -> IO PyObj
 wrapPythonTyCon    =  c_wrapPythonTyCon . castStablePtrToPtr <=< newStablePtr
 
-foreign import ccall c_unwrapPythonHsType :: PyObj -> WStPtr
+foreign import ccall unsafe c_unwrapPythonHsType :: PyObj -> WStPtr
 unwrapPythonHsType :: PyObj -> IO HsType
 unwrapPythonHsType = deRefStablePtr . castPtrToStablePtr . c_unwrapPythonHsType
 
-foreign import ccall c_wrapPythonHsType  :: WStPtr -> IO PyObj
+foreign import ccall unsafe c_wrapPythonHsType  :: WStPtr -> IO PyObj
 wrapPythonHsType   :: HsType  -> IO PyObj
 wrapPythonHsType   =  c_wrapPythonHsType . castStablePtrToPtr <=< newStablePtr
 
-foreign import ccall c_wrapPythonHsObjRaw  :: WStPtr -> IO PyObj
+foreign import ccall unsafe c_unwrapPythonHsObjRaw :: PyObj -> WStPtr
+unwrapPythonHsObjRaw :: PyObj -> IO HsObj
+unwrapPythonHsObjRaw = deRefStablePtr . castPtrToStablePtr . c_unwrapPythonHsObjRaw
+
+foreign import ccall unsafe c_wrapPythonHsObjRaw  :: WStPtr -> IO PyObj
 wrapPythonHsObjRaw   :: HsObj -> IO PyObj
 wrapPythonHsObjRaw = c_wrapPythonHsObjRaw . castStablePtrToPtr <=< newStablePtr
 
-foreign import ccall c_unwrapPythonHsObjRaw :: PyObj -> WStPtr
-unwrapPythonHsObjRaw :: PyObj -> IO HsObj
-unwrapPythonHsObjRaw = deRefStablePtr . castPtrToStablePtr . c_unwrapPythonHsObjRaw

--- a/hyphen/lowlevel_src/PythonBase.hs
+++ b/hyphen/lowlevel_src/PythonBase.hs
@@ -69,10 +69,10 @@ foreign import ccall safe   "&py_DECREF_with_GIL_acq" addr_py_DECREF :: FunPtr (
 foreign import ccall safe   py_DECREF            :: PyObj -> IO ()
 foreign import ccall unsafe py_INCREF            :: PyObj -> IO ()
 foreign import ccall safe   pyModule_AddObject   :: PyObj -> CString -> PyObj -> IO Int
-foreign import ccall unsafe pyGILState_Ensure    :: IO (Ptr ())
-foreign import ccall unsafe pyGILState_Release   :: Ptr () -> IO ()
-foreign import ccall unsafe pyEval_SaveThread    :: IO (Ptr ())
-foreign import ccall unsafe pyEval_RestoreThread :: Ptr () -> IO ()
+foreign import ccall safe   pyGILState_Ensure    :: IO (Ptr ())
+foreign import ccall safe   pyGILState_Release   :: Ptr () -> IO ()
+foreign import ccall safe   pyEval_SaveThread    :: IO (Ptr ())
+foreign import ccall safe   pyEval_RestoreThread :: Ptr () -> IO ()
 
 foreign import ccall unsafe exHsException        :: IO PyObj
 foreign import ccall unsafe exKeyboardInterrupt  :: IO PyObj

--- a/hyphen/lowlevel_src/PythonBase.hs
+++ b/hyphen/lowlevel_src/PythonBase.hs
@@ -39,52 +39,52 @@ nullPyObj = (nullPtr :: PyObj)
 -- (say) HsPtr and whatever the Python library is using are compatible
 -- types.)
 
-foreign import ccall c_pyTypeErr          :: CString -> IO PyObj
-foreign import ccall c_pyValueErr         :: CString -> IO PyObj
-foreign import ccall c_getHsExceptionAttr :: PyObj -> IO PyObj
-foreign import ccall c_installHaskellCtrlCHandler  :: IO Int
-foreign import ccall c_reinstallPythonCtrlCHandler :: IO Int
-foreign import ccall c_makeHaskellText    :: PyObj -> IO PyObj
+foreign import ccall unsafe c_pyTypeErr          :: CString -> IO PyObj
+foreign import ccall unsafe c_pyValueErr         :: CString -> IO PyObj
+foreign import ccall safe   c_getHsExceptionAttr :: PyObj -> IO PyObj
+foreign import ccall unsafe c_installHaskellCtrlCHandler  :: IO Int
+foreign import ccall unsafe c_reinstallPythonCtrlCHandler :: IO Int
+foreign import ccall safe   c_makeHaskellText    :: PyObj -> IO PyObj
 foreign import ccall unsafe c_isThisTheMainPythonThread :: IO Bool
-foreign import ccall pyErr_NoMemory       :: IO PyObj
-foreign import ccall pyErr_Fetch          :: Ptr PyObj -> Ptr PyObj -> Ptr PyObj -> IO ()
-foreign import ccall pyErr_NormalizeException
+foreign import ccall unsafe pyErr_NoMemory       :: IO PyObj
+foreign import ccall unsafe pyErr_Fetch          :: Ptr PyObj -> Ptr PyObj -> Ptr PyObj -> IO ()
+foreign import ccall safe   pyErr_NormalizeException
                                           :: Ptr PyObj -> Ptr PyObj -> Ptr PyObj -> IO ()
-foreign import ccall pyErr_Restore        :: PyObj -> PyObj -> PyObj -> IO ()
-foreign import ccall pyErr_SetObject      :: PyObj -> PyObj -> IO ()
-foreign import ccall pyErr_CheckSignals   :: IO Int
-foreign import ccall pyTuple_New          :: Int -> IO PyObj
-foreign import ccall pyTuple_GET_ITEM     :: PyObj -> Int -> IO PyObj
-foreign import ccall pyTuple_SET_ITEM     :: PyObj -> Int -> PyObj -> IO ()
-foreign import ccall pyTuple_Size         :: PyObj -> IO Int
-foreign import ccall pyUnicode_Check      :: PyObj -> IO Bool
-foreign import ccall pyCallable_Check     :: PyObj -> IO Bool
-foreign import ccall pyObject_Str         :: PyObj -> IO PyObj
-foreign import ccall pyObject_SetAttr     :: PyObj -> PyObj -> PyObj -> IO Int
-foreign import ccall pyObject_Call        :: PyObj -> PyObj -> PyObj -> IO PyObj
-foreign import ccall pyDict_New           :: IO PyObj
-foreign import ccall pyDict_Next  :: PyObj -> Ptr Int -> Ptr PyObj -> Ptr PyObj -> IO Int
-foreign import ccall pyDict_SetItem       :: PyObj -> PyObj -> PyObj -> IO Int
-foreign import ccall "&py_DECREF_with_GIL_acq" addr_py_DECREF :: FunPtr (PyObj -> IO ())
-foreign import ccall py_DECREF            :: PyObj -> IO ()
-foreign import ccall py_INCREF            :: PyObj -> IO ()
-foreign import ccall pyModule_AddObject   :: PyObj -> CString -> PyObj -> IO Int
-foreign import ccall pyGILState_Ensure    :: IO (Ptr ())
-foreign import ccall pyGILState_Release   :: Ptr () -> IO ()
-foreign import ccall pyEval_SaveThread    :: IO (Ptr ())
-foreign import ccall pyEval_RestoreThread :: Ptr () -> IO ()
+foreign import ccall unsafe pyErr_Restore        :: PyObj -> PyObj -> PyObj -> IO ()
+foreign import ccall safe   pyErr_SetObject      :: PyObj -> PyObj -> IO ()
+foreign import ccall safe   pyErr_CheckSignals   :: IO Int
+foreign import ccall unsafe pyTuple_New          :: Int -> IO PyObj
+foreign import ccall unsafe pyTuple_GET_ITEM     :: PyObj -> Int -> IO PyObj
+foreign import ccall unsafe pyTuple_SET_ITEM     :: PyObj -> Int -> PyObj -> IO ()
+foreign import ccall unsafe pyTuple_Size         :: PyObj -> IO Int
+foreign import ccall unsafe pyUnicode_Check      :: PyObj -> IO Bool
+foreign import ccall unsafe pyCallable_Check     :: PyObj -> IO Bool
+foreign import ccall safe   pyObject_Str         :: PyObj -> IO PyObj
+foreign import ccall safe   pyObject_SetAttr     :: PyObj -> PyObj -> PyObj -> IO Int
+foreign import ccall safe   pyObject_Call        :: PyObj -> PyObj -> PyObj -> IO PyObj
+foreign import ccall unsafe pyDict_New           :: IO PyObj
+foreign import ccall unsafe pyDict_Next  :: PyObj -> Ptr Int -> Ptr PyObj -> Ptr PyObj -> IO Int
+foreign import ccall safe   pyDict_SetItem       :: PyObj -> PyObj -> PyObj -> IO Int -- safe because we need to compute a hash
+foreign import ccall safe   "&py_DECREF_with_GIL_acq" addr_py_DECREF :: FunPtr (PyObj -> IO ())
+foreign import ccall safe   py_DECREF            :: PyObj -> IO ()
+foreign import ccall unsafe py_INCREF            :: PyObj -> IO ()
+foreign import ccall safe   pyModule_AddObject   :: PyObj -> CString -> PyObj -> IO Int
+foreign import ccall unsafe pyGILState_Ensure    :: IO (Ptr ())
+foreign import ccall unsafe pyGILState_Release   :: Ptr () -> IO ()
+foreign import ccall unsafe pyEval_SaveThread    :: IO (Ptr ())
+foreign import ccall unsafe pyEval_RestoreThread :: Ptr () -> IO ()
 
-foreign import ccall exHsException        :: IO PyObj
-foreign import ccall exKeyboardInterrupt  :: IO PyObj
-foreign import ccall exOverflowError      :: IO PyObj
-foreign import ccall exZeroDivisionError  :: IO PyObj
-foreign import ccall exFloatingPointError :: IO PyObj
-foreign import ccall exAttributeError     :: IO PyObj
-foreign import ccall exSystemExit         :: IO PyObj
-foreign import ccall exEOFError           :: IO PyObj
+foreign import ccall unsafe exHsException        :: IO PyObj
+foreign import ccall unsafe exKeyboardInterrupt  :: IO PyObj
+foreign import ccall unsafe exOverflowError      :: IO PyObj
+foreign import ccall unsafe exZeroDivisionError  :: IO PyObj
+foreign import ccall unsafe exFloatingPointError :: IO PyObj
+foreign import ccall unsafe exAttributeError     :: IO PyObj
+foreign import ccall unsafe exSystemExit         :: IO PyObj
+foreign import ccall unsafe exEOFError           :: IO PyObj
 
-foreign import ccall py_NotImplemented    :: IO PyObj
-foreign import ccall py_None              :: IO PyObj
+foreign import ccall unsafe py_NotImplemented    :: IO PyObj
+foreign import ccall unsafe py_None              :: IO PyObj
 
 -- | Set a python TypeError Exception with the provided Text
 

--- a/hyphen/lowlevel_src/Pythonate.hs
+++ b/hyphen/lowlevel_src/Pythonate.hs
@@ -45,14 +45,14 @@ import PythonBase
 -- superfluous and putting it in PythonM would make extra work for
 -- ourselves.
 
-foreign import ccall pythonateInt        :: Int        -> IO PyObj
-foreign import ccall pythonateFloat      :: Float      -> IO PyObj
-foreign import ccall pythonateDouble     :: Double     -> IO PyObj
-foreign import ccall pythonateUTF16Ptr   :: Ptr Word16 -> Int -> IO PyObj
-foreign import ccall pythonateBytePtr    :: CString    -> Int -> IO PyObj
-foreign import ccall pythonateTrue       :: IO PyObj
-foreign import ccall pythonateFalse      :: IO PyObj
-foreign import ccall pythonateIntegerFromStr :: Ptr Word16 -> Int -> IO PyObj
+foreign import ccall unsafe pythonateInt        :: Int        -> IO PyObj
+foreign import ccall unsafe pythonateFloat      :: Float      -> IO PyObj
+foreign import ccall unsafe pythonateDouble     :: Double     -> IO PyObj
+foreign import ccall unsafe pythonateUTF16Ptr   :: Ptr Word16 -> Int -> IO PyObj
+foreign import ccall unsafe pythonateBytePtr    :: CString    -> Int -> IO PyObj
+foreign import ccall unsafe pythonateTrue       :: IO PyObj
+foreign import ccall unsafe pythonateFalse      :: IO PyObj
+foreign import ccall unsafe pythonateIntegerFromStr :: Ptr Word16 -> Int -> IO PyObj
 
 pythonateBool         :: Bool    -> IO PyObj
 pythonateBool b       = if b then pythonateTrue else pythonateFalse

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -618,7 +618,7 @@ c_wrapPythonTyCon(HsPtr stablePtr)
 HsBool
 pyTyCon_Check(HsPtr obj)
 {
-  return PyObject_IsInstance(obj, (PyObject*) &TyConType);
+  return PyType_IsSubtype(((PyObject*)obj)->ob_type, &TyConType);
 }
 
 /************************************************************
@@ -789,7 +789,7 @@ parseTupleToPythonHsType(HsPtr args)
 HsBool
 pyHsType_Check(HsPtr obj)
 {
-  return PyObject_IsInstance(obj, (PyObject*) &HsTypeType);
+  return PyType_IsSubtype(((PyObject*)obj)->ob_type, &HsTypeType);
 }
 
 /************************************************************
@@ -900,6 +900,15 @@ static PyTypeObject HsObjRawType = {
   HsObjRaw_new,                 /* tp_new */
 };
 
+/* Given a Stable pointer to a Haskell HsObjRaw, wrap it into a Python
+   HsObjRaw*/
+
+HsPtr
+c_unwrapPythonHsObjRaw(HsPtr self)
+{
+  return ((HsObjRaw*) self)->objStablePtr;
+}
+
 /* Given a pointer to a Python HsObjRaw, extract the stable ptr to the
    underlying Haskell object */
 
@@ -916,15 +925,6 @@ c_wrapPythonHsObjRaw(HsPtr objStablePtr)
   }
 
   return (PyObject *)self;
-}
-
-/* Given a Stable pointer to a Haskell HsObjRaw, wrap it into a Python
-   HsObjRaw*/
-
-HsPtr
-c_unwrapPythonHsObjRaw(HsPtr self)
-{
-  return ((HsObjRaw*) self)->objStablePtr;
 }
 
 /* Given a tuple which consists of a single HsObjRaw, pull out the
@@ -946,7 +946,7 @@ parseTupleToPythonHsObjRaw(HsPtr args)
 HsBool
 pyHsObjRaw_Check(HsPtr obj)
 {
-  return PyObject_IsInstance(obj, (PyObject*) &HsObjRawType);
+  return PyType_IsSubtype(((PyObject*)obj)->ob_type, &HsObjRawType);
 }
 
 /************************************************************


### PR DESCRIPTION
The code currently uses "safe" for all c functions "foreign import"ed
into Haskell. (Implicitly, since it is the default.)  It is more
efficient to use "unsafe" where this is allowed.  (Specifically, when
the foreign function is known to never call back into Haskell code.)
This patch makes us more thoughtful, using "unsafe" imports where
appropriate