### PR TITLE
Better handling of exceptions

### DIFF
--- a/Test.hs
+++ b/Test.hs
@@ -4,6 +4,7 @@ module Test where
 
 import Data.Maybe
 import Data.Typeable
+import Control.Exception
 
 foo :: Integer -> Integer
 foo = (+ 1)
@@ -21,3 +22,12 @@ hy__Test__getitem__ (Test i) j = i + j
 
 data Example = ExampleWithInt    Int
              | ExampleWithString String deriving (Typeable, Show)
+
+
+data TestException = TestException Integer deriving (Show)
+
+instance Exception(TestException)
+
+do_and_catch_testexception :: IO () -> IO ()
+do_and_catch_testexception action =
+  do Control.Exception.catch action (\ (TestException i) -> return ())

--- a/hyphen/lowlevel_src/Hyphen.hs
+++ b/hyphen/lowlevel_src/Hyphen.hs
@@ -39,10 +39,10 @@ import qualified Data.Text.Read
 import qualified Data.Text.Encoding
 import qualified Data.ByteString
 import qualified Data.Traversable
-import qualified Control.Exception as Exception
 import qualified Unsafe.Coerce
 import qualified GHC
 #if !defined(mingw32_HOST_OS)
+import qualified Control.Exception as Exception
 import qualified System.Posix.Signals
 #endif
 import qualified System.Mem.Weak

--- a/hyphen/lowlevel_src/Hyphen.hs
+++ b/hyphen/lowlevel_src/Hyphen.hs
@@ -10,7 +10,7 @@ import Control.Monad
 import Control.Monad.Trans.Maybe
 import Control.Monad.State.Strict
 import Control.Exception (
-  SomeException, toException, assert, AsyncException(..), try)
+  SomeException, assert, AsyncException(..), try)
 import Control.Concurrent
 import Control.DeepSeq
 import Data.IORef
@@ -39,10 +39,10 @@ import qualified Data.Text.Read
 import qualified Data.Text.Encoding
 import qualified Data.ByteString
 import qualified Data.Traversable
+import qualified Control.Exception as Exception
 import qualified Unsafe.Coerce
 import qualified GHC
 #if !defined(mingw32_HOST_OS)
-import qualified Control.Exception as Exception
 import qualified System.Posix.Signals
 #endif
 import qualified System.Mem.Weak
@@ -322,7 +322,7 @@ setupHaskellCtrlCHandler = captureAsyncExceptions_IntReturn . const $ do
         stetc <- getSpecialThreadAndSPRS
         case stetc of
           Nothing        -> return ()
-          Just (tid, _)  -> Exception.throwTo tid (toException UserInterrupt)
+          Just (tid, _)  -> Exception.throwTo tid (Exception.toException UserInterrupt)
   System.Posix.Signals.installHandler System.Posix.Signals.sigINT handler Nothing
   return 0
 #else

--- a/hyphen/lowlevel_src/Hyphen_stub.h
+++ b/hyphen/lowlevel_src/Hyphen_stub.h
@@ -2,7 +2,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-extern void setupHaskellCtrlCHandler(void);
+extern HsInt setupHaskellCtrlCHandler(void);
 extern HsInt tycon_hash(HsPtr a1);
 extern HsPtr tycon_richcmp(HsPtr a1, HsPtr a2, HsInt a3);
 extern HsPtr tycon_str(HsPtr a1);

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -1402,7 +1402,13 @@ PyInit_hslowlevel(void)
 #endif
   hs_init(0, 0);
 #if !defined(mingw32_HOST_OS)
-  setupHaskellCtrlCHandler();
+  int failed = setupHaskellCtrlCHandler();
+  if (failed)
+    {
+      PyOS_setsig(SIGINT, python_siginthandler);
+      Py_DECREF(m);
+      return NULL;
+    }
   haskell_siginthandler = PyOS_getsig(SIGINT);
   PyOS_setsig(SIGINT, python_siginthandler);
 #endif

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -153,7 +153,7 @@ py_DECREF(HsPtr obj)
 void
 py_DECREF_with_GIL_acq(HsPtr obj)
 {
-  if (ghc_interpreter_state)
+  if (obj && ghc_interpreter_state)
     {
       PyGILState_STATE gstate;
       gstate = PyGILState_Ensure();

--- a/hyphen_examples_full.py
+++ b/hyphen_examples_full.py
@@ -1,5 +1,4 @@
-"""
-Roundtrips
+"""Roundtrips
 ==========
 
 >>> import hyphen, hs.Prelude
@@ -100,6 +99,35 @@ False
 <class 'hs.Test.Test'>
 >>> hs.Test.foo(3)
 4
+
+>>> import hyphen
+>>> import hs.Control.Exception
+>>> IO_returning_emptytup = hs.Control.Exception.allowInterrupt.hstype
+>>> hs.Control.Exception.throwIO(hs.Control.Exception.ThreadKilled()).narrow_type(IO_returning_emptytup)
+<hs.GHC.Types.IO object of Haskell type GHC.Types.IO ()>
+>>> hs.Control.Exception.throwIO(hs.Control.Exception.ThreadKilled()).narrow_type(IO_returning_emptytup).act()
+Traceback (most recent call last):
+...
+hyphen.HsException: thread killed
+>>> try:
+...     hs.Control.Exception.throwIO(hs.Control.Exception.ThreadKilled()).narrow_type(IO_returning_emptytup).act()
+... except hyphen.HsException as e:
+...     print(type(e))
+...     print(type(e.hs_exception))
+...     print(e.hs_exception.hstype)
+...     print(hs.Prelude.show(e.hs_exception))
+<class 'hyphen.HsException'>
+<class 'hsobjraw.HsObjRaw'>
+<hyphen.HsType object representing GHC.Exception.SomeException>
+thread killed
+
+
+Check that when exceptions raised in Haskell propagate through Python
+code and back into Haskell, they are properly re-constituted.
+>>> def raise_test_exception():
+...    hs.Control.Exception.throwIO(hs.Test.TestException(3)).narrow_type(IO_returning_emptytup).act()
+>>> hs.Test.do_and_catch_testexception(raise_test_exception)
+<hs.GHC.Types.IO object of Haskell type GHC.Types.IO ()>
 """
 
 import sys


### PR DESCRIPTION
Previously we assumed that every Python Exception would eventually be
re-released into Python, which is not correct. To ensure correct
behavior in the case where Haskell handles the exception, we must use
ForeignPtrs

Also add more tests for various edge cases in exception propagation.

Finally, improve handling of asynchronous exceptions, ensuring that they are masked in most hyphen code and properly handled (previously they would cause a crash if they arrived in hyphen code, although they were correctly handled if they arrived in user Haskell code...)