### PR TITLE
update for changes upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         stack: ["2.3.1"]
 # GHC version here doesn't really matter because stack picks one from the LTS
         bootstrap_ghc: ["8.10.5"]
-        resolver: ["lts-16.31", "lts-18.23", "nightly-2022-01-027"] # GHC 8.8, 8.10, 9.0
+        resolver: ["lts-16.31", "lts-18.23", "nightly-2022-01-27"] # GHC 8.8, 8.10, 9.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         stack: ["2.3.1"]
 # GHC version here doesn't really matter because stack picks one from the LTS
         bootstrap_ghc: ["8.10.5"]
-        resolver: ["lts-16.31", "lts-18.16", "nightly-2021-11-06"] # GHC 8.8, 8.10, 9.0
+        resolver: ["lts-16.31", "lts-18.23", "nightly-2022-01-027"] # GHC 8.8, 8.10, 9.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         stack: ["2.3.1"]
 # GHC version here doesn't really matter because stack picks one from the LTS
         bootstrap_ghc: ["8.10.5"]
-        resolver: ["lts-16.31", "lts-18.23", "nightly-2022-01-27"] # GHC 8.8, 8.10, 9.0
+        resolver: ["lts-16.31", "lts-18.23", "nightly-2021-11-06"] # GHC 8.8, 8.10, 9.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1.1.4

--- a/hyphen/lowlevel_src/Hyphen_stub.h
+++ b/hyphen/lowlevel_src/Hyphen_stub.h
@@ -1,5 +1,5 @@
-#include "HsFFI.h"
-#ifdef __cplusplus
+#include <HsFFI.h>
+#if defined(__cplusplus)
 extern "C" {
 #endif
 extern HsInt setupHaskellCtrlCHandler(void);
@@ -67,7 +67,7 @@ extern HsPtr ok_python_identif(HsPtr a1, HsPtr a2);
 extern HsPtr hyphen_apply(HsPtr a1, HsPtr a2);
 extern HsPtr hyphen_doio_impl(HsInt a1, HsInt a2, HsPtr a3);
 extern HsPtr hyphen_wrap_pyfn_impl(HsPtr a1, HsPtr a2, HsInt a3);
-#ifdef __cplusplus
+#if defined(__cplusplus)
 }
 #endif
 

--- a/hyphen/lowlevel_src/Hyphen_stub.h
+++ b/hyphen/lowlevel_src/Hyphen_stub.h
@@ -1,5 +1,5 @@
-#include <HsFFI.h>
-#if defined(__cplusplus)
+#include "HsFFI.h"
+#ifdef __cplusplus
 extern "C" {
 #endif
 extern HsInt setupHaskellCtrlCHandler(void);
@@ -67,7 +67,7 @@ extern HsPtr ok_python_identif(HsPtr a1, HsPtr a2);
 extern HsPtr hyphen_apply(HsPtr a1, HsPtr a2);
 extern HsPtr hyphen_doio_impl(HsInt a1, HsInt a2, HsPtr a3);
 extern HsPtr hyphen_wrap_pyfn_impl(HsPtr a1, HsPtr a2, HsInt a3);
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 

--- a/hyphen/lowlevel_src/Pythonate.hs
+++ b/hyphen/lowlevel_src/Pythonate.hs
@@ -49,10 +49,21 @@ foreign import ccall unsafe pythonateInt        :: Int        -> IO PyObj
 foreign import ccall unsafe pythonateFloat      :: Float      -> IO PyObj
 foreign import ccall unsafe pythonateDouble     :: Double     -> IO PyObj
 foreign import ccall unsafe pythonateUTF16Ptr   :: Ptr Word16 -> Int -> IO PyObj
+foreign import ccall unsafe pythonateUTF8Ptr    :: Ptr Word8  -> Int -> IO PyObj
 foreign import ccall unsafe pythonateBytePtr    :: CString    -> Int -> IO PyObj
 foreign import ccall unsafe pythonateTrue       :: IO PyObj
 foreign import ccall unsafe pythonateFalse      :: IO PyObj
-foreign import ccall unsafe pythonateIntegerFromStr :: Ptr Word16 -> Int -> IO PyObj
+foreign import ccall unsafe pythonateIntegerFromUTF16Str :: Ptr Word16 -> Int -> IO PyObj
+foreign import ccall unsafe pythonateIntegerFromUTF8Str  :: Ptr Word8  -> Int -> IO PyObj
+
+class PythonateUTF a where
+  pythonateUTFPtr :: Ptr a -> Int -> IO PyObj
+  pythonateIntegerFromStr :: Ptr a -> Int -> IO PyObj
+
+instance PythonateUTF Word16 where pythonateUTFPtr = pythonateUTF16Ptr
+                                   pythonateIntegerFromStr = pythonateIntegerFromUTF16Str
+instance PythonateUTF Word8  where pythonateUTFPtr = pythonateUTF8Ptr
+                                   pythonateIntegerFromStr = pythonateIntegerFromUTF8Str
 
 pythonateBool         :: Bool    -> IO PyObj
 pythonateBool b       = if b then pythonateTrue else pythonateFalse
@@ -64,8 +75,8 @@ pythonateString       :: String  -> IO PyObj
 pythonateString       = pythonateText . T.pack
 
 pythonateText         :: Text    -> IO PyObj
-pythonateText t       = Data.Text.Foreign.useAsPtr t pythonateUTF16Ptr'
-  where pythonateUTF16Ptr' ptr i16 = pythonateUTF16Ptr ptr (fromInteger $ toInteger i16)
+pythonateText t       = Data.Text.Foreign.useAsPtr t pythonateUTFPtr'
+  where pythonateUTFPtr' ptr i16 = pythonateUTFPtr ptr (fromInteger $ toInteger i16)
 
 pythonateByteString   :: ByteString    -> IO PyObj
 pythonateByteString t = Data.ByteString.Unsafe.unsafeUseAsCStringLen t

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -1080,14 +1080,14 @@ to_haskell_String(PyObject *self, PyObject *args)
 {
   char        *buffer=0;
   Py_ssize_t   buffer_length=-1;
-  if (!PyArg_ParseTuple(args, "es#:to_haskell_String", "utf-16", &buffer, &buffer_length))
+  if (!PyArg_ParseTuple(args, "es#:to_haskell_String", "utf-8", &buffer, &buffer_length))
     {
       return NULL;
     }
 
   /* Ingore first two bytes of encoded string; they are the BOM. Also
      convert length from bytes to UTF-16 words. */
-  PyObject *ret = buildHaskellString((HsPtr) (buffer+2), (buffer_length-2)/2);
+  PyObject *ret = buildHaskellString((HsPtr) buffer, buffer_length);
   PyMem_Free(buffer);
   return ret;
 }
@@ -1097,14 +1097,14 @@ to_haskell_Text(PyObject *self, PyObject *args)
 {
   char       *buffer=0;
   Py_ssize_t  buffer_length=-1;
-  if (!PyArg_ParseTuple(args, "es#:to_haskell_Text", "utf-16", &buffer, &buffer_length))
+  if (!PyArg_ParseTuple(args, "es#:to_haskell_Text", "utf-8", &buffer, &buffer_length))
     {
       return NULL;
     }
 
   /* Ingore first two bytes of encoded string; they are the BOM. Also
      convert length from bytes to UTF-16 words. */
-  PyObject *ret = buildHaskellText((HsPtr) (buffer+2), (buffer_length-2)/2);
+  PyObject *ret = buildHaskellText((HsPtr) buffer, buffer_length);
   PyMem_Free(buffer);
   return ret;
 }

--- a/hyphen/lowlevel_src/hyphen_c.c
+++ b/hyphen/lowlevel_src/hyphen_c.c
@@ -231,6 +231,14 @@ pythonateUTF16Ptr(const Py_UCS2* s, HsInt size)
 }
 
 HsPtr
+pythonateUTF8Ptr(const char* s, HsInt size)
+{
+  /* Create a python string object from a pointer to UTF16 data and a
+     string length. */
+  return PyUnicode_DecodeUTF8(s, size, NULL);
+}
+
+HsPtr
 pythonateBytePtr(const char* s, HsInt size)
 {
   /* Create a python bytes object from a pointer to data and a string length. */
@@ -250,13 +258,35 @@ pythonateFalse()
 }
 
 HsPtr
-pythonateIntegerFromStr(const Py_UCS2* s, HsInt size)
+pythonateIntegerFromUTF16Str(const Py_UCS2* s, HsInt size)
 {
   /* Create a python integer object from a pointer to a buffer
      containing the number encoded in hex as a UTF16 string. Only used
      for numbers too long to fit in a long. */
   PyObject *str, *num;
   str = PyUnicode_DecodeUTF16((char*) s, size*2, NULL, NULL);
+  if (!str)
+    {
+      return 0;
+    }
+
+  num = PyLong_FromUnicodeObject(str, 16);
+  if (!num)
+    {
+      Py_DECREF(str);
+      return 0;
+    }
+  return num;
+}
+
+HsPtr
+pythonateIntegerFromUTF8Str(const char* s, HsInt size)
+{
+  /* Create a python integer object from a pointer to a buffer
+     containing the number encoded in hex as a UTF16 string. Only used
+     for numbers too long to fit in a long. */
+  PyObject *str, *num;
+  str = PyUnicode_DecodeUTF8(s, size, NULL);
   if (!str)
     {
       return 0;

--- a/hyphen/marshall_ctor.py
+++ b/hyphen/marshall_ctor.py
@@ -32,7 +32,10 @@ below.
 
 from __future__           import absolute_import
 
-import collections
+try:
+    import collections.abc as abc
+except:
+    import collections     as abc
 
 import hyphen
 from hyphen.caches import fetch_lib_module
@@ -425,13 +428,13 @@ tycon_specials = {
         "__getitem__" : map_lookup,
         "__iter__"    : iterate_hsmap,
         "__len__"     : member_from_unary_hsfn(hs_sizeOfMap),
-        "BASES"       : (collections.Mapping,),
+        "BASES"       : (abc.Mapping,),
         },
     hs_Set : {
         "__contains__" : set_member,
         "__iter__"     : iterate_hsset,
         "__len__"      : member_from_unary_hsfn(hs_sizeOfSet),
-        "BASES"        : (collections.Set,),
+        "BASES"        : (abc.Set,),
         },
     hs_Func : {
         "__call__"    : apply_marshalled,
@@ -448,7 +451,7 @@ tycon_specials = {
 tycon_specials.update(dict([(tup_tyc, {
     "__getitem__" : tuple_getitem,
     "__len__"     : const_fn(tup_len),
-    "BASES"       : (collections.Sequence,),
+    "BASES"       : (abc.Sequence,),
     }) for tup_len, tup_tyc in enumerate(hs_tupletycs_bylength)]))
 
 # The second kind of hook affects the types we build to represent

--- a/hyphen/marshall_obj_to_hs.py
+++ b/hyphen/marshall_obj_to_hs.py
@@ -26,7 +26,11 @@ hooks, so users can extend the built-in handing if they so desire.
 
 from __future__           import absolute_import
 
-import collections, types
+try:
+    import collections.abc as abc
+except:
+    import collections     as abc
+import types
 
 from hyphen.utils  import (
     hs_Complex, hs_Maybe, hs_List, hs_Set, hs_Map, hs_IO, hs_Func,
@@ -433,9 +437,9 @@ pyobj_hstype_hint_per_type_hooks = {
 # hand
 
 pyobj_hstype_hint_general_hooks = [
-    whenInst(collections.Sequence, sequence_hstype_hint),
-    whenInst(collections.Mapping,  mapping_hstype_hint),
-    whenInst(collections.Set,      set_hstype_hint),
+    whenInst(abc.Sequence, sequence_hstype_hint),
+    whenInst(abc.Mapping,  mapping_hstype_hint),
+    whenInst(abc.Set,      set_hstype_hint),
 ]
 
 

--- a/hyphen_examples.py
+++ b/hyphen_examples.py
@@ -231,10 +231,10 @@ hs.GHC.Prim._['(->)'](hyphen.HsType("a"), hyphen.HsType("a"))
 >>> int_identity = hs.Prelude.id.subst(a=hs.Prelude.Int())
 >>> int_identity
 <hyphen.HsFunObj object of Haskell type GHC.Types.Int -> GHC.Types.Int>
->>> int_identity('Foo')
+>>> int_identity('Foo') # doctest: +ELLIPSIS
 Traceback (most recent call last):
 ...
-TypeError: an integer is required (got type str)
+TypeError: ...
 >>> int_identity(1)
 1
 >>> hs.Prelude.id.narrow_type(int_identity.hstype)


### PR DESCRIPTION
The Python abstract base classes have moved to collections.abc.

Data.Text is beginning to switch over to a UTF8 internal rep.

Also bump the stackage referrers.