### PR TITLE
Install on debian Linux distros (Ubuntu) with one script

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -87,6 +87,9 @@ Finally, you should be able to do `build-extn.py` as per the general instruction
 Ubuntu
 ------
 
+After downloading, you should just be able to run `Install_Hyphen_deb.bash' 
+and it will take care of all of this.
+
 Before you build, you obviously need to make sure you have python3 and
 ghc installed. You also need to make sure you have the ghc-dynamic
 package (necessary to allow ghc to build and use dynamic modules) and

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -87,7 +87,7 @@ Finally, you should be able to do `build-extn.py` as per the general instruction
 Ubuntu
 ------
 
-After downloading, you should just be able to run `Install_Hyphen_deb.bash' 
+After downloading, you should just be able to run `Install_Hyphen_deb.bash` 
 and it will take care of all of this.
 
 Before you build, you obviously need to make sure you have python3 and

--- a/Install_Hyphen_Deb.bash
+++ b/Install_Hyphen_Deb.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#This script is for Debian based linux versions, Sudo expected, tested on ubuntu 22.04.1, runs up to line 25
+
+
+#Ensure Python3 is installed with dev packages
+echo "get python 3 with the dev"
+sudo apt-get install python3-dev ghc-dynamic ghc python3
+#Ensure we can cabal install
+echo "Get the stuff we need to do a Cabal install"
+curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+
+
+#now we do the actual installing
+#Get hyphen
+#echo "downloading hyphen"
+#git clone https://github.com/tbarnetlamb/hyphen.git
+
+#Calling what's needed
+cabal install --enable-shared
+#move to the file the python things are in
+#cd hyphen
+cd hyphen
+echo "building hyphen"
+build-extn.py
+echo "Testing Hyphen"
+cd ..
+python3 hyphen_examples.py
+echo "done"

--- a/Install_Hyphen_Deb.bash
+++ b/Install_Hyphen_Deb.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 #This script is for Debian based linux versions, Sudo expected, tested on ubuntu 22.04.1, runs up to line 25
+#Hopefully we can create this, but for the other platforms as well.
 
 
 #Ensure Python3 is installed with dev packages

--- a/Install_Hyphen_OSX.bat
+++ b/Install_Hyphen_OSX.bat
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#This script is for OSX, hopefully runs up to line 20, Assuming GHC and Python 3
+#I have no way of testing this
+
+#Ensure we can cabal install
+echo "Get the stuff we need to do a Cabal install"
+cabal install --reinstall --force-reinstalls --enable-shared text
+cabal install --reinstall --force-reinstalls --enable-shared transformers
+cabal install --reinstall --force-reinstalls --enable-shared mtl
+cabal install --reinstall --force-reinstalls --enable-shared parsec
+cabal install --reinstall --force-reinstalls --enable-shared hashable
+cabal install --reinstall --force-reinstalls --enable-shared unordered-containers
+cabal install --enable-shared --reinstall ghc-paths
+
+#move to the file the python things are in
+cd hyphen
+echo "building hyphen"
+build-extn.py
+echo "Testing Hyphen"
+cd ..
+python3 hyphen_examples.py
+echo "done"


### PR DESCRIPTION
This PR should make it so Hyphen will install itself by running a single script. `Install_Hyphen_deb.bash' 
It is tested and works up to deprecation errors.